### PR TITLE
[WIP] Multiple token signing

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,10 +83,9 @@ function toWebsafeBase64(buf) {
 }
 
 // Build a FIDO challenge
-function buildChallenge(appId, keyHandle) {
+function buildChallenge(keyHandle) {
     var challenge = {
         version: "U2F_V2",
-        appId: appId,
         challenge: toWebsafeBase64(crypto.randomBytes(32))
     };
 
@@ -116,7 +115,7 @@ function requestRegistration(appId, options) {
     
     // Add registration challenge
     // Note that multiple enrolmenet is viable but not implemented
-    res.registerRequests = [buildChallenge(appId)];
+    res.registerRequests = [buildChallenge()];
 
     res.registeredKeys = [];
 
@@ -158,7 +157,7 @@ function requestSignature(appId, keyHandles, options) {
     }
 
     // Build signing challenge
-    var res = buildChallenge(appId);
+    var res = buildChallenge();
     res.appId = appId;
     res.type = "u2f_sign_request"
 

--- a/index.js
+++ b/index.js
@@ -198,8 +198,6 @@ function requestSignature(appId, keyHandles, options) {
 // request: {version, appId, challenge} - from user session, kept on server.
 // registerData: {clientData, registrationData} - result of u2f.register
 function checkRegistration(request, registerData) {
-    console.log("CheckRegistration request:")
-    console.log(request);
     if (typeof request !== 'object') {
         return {errorMessage: "Invalid request object"};
     }

--- a/index.js
+++ b/index.js
@@ -198,8 +198,14 @@ function requestSignature(appId, keyHandles, options) {
 // request: {version, appId, challenge} - from user session, kept on server.
 // registerData: {clientData, registrationData} - result of u2f.register
 function checkRegistration(request, registerData) {
-    if (typeof registerData !== 'object')
+    console.log("CheckRegistration request:")
+    console.log(request);
+    if (typeof request !== 'object') {
+        return {errorMessage: "Invalid request object"};
+    }
+    if (typeof registerData !== 'object') {
         return {errorMessage: "Invalid response from U2F token."};
+    }
 
     // Check registration error
     if (registerData.errorCode)
@@ -216,7 +222,9 @@ function checkRegistration(request, registerData) {
     catch (e) {
         return {errorMessage: "Invalid clientData: not a valid JSON object"}
     }
-    if (clientDataObj.challenge !== request.challenge)
+
+    var challenge = request.registerRequests[0].challenge;
+    if (clientDataObj.challenge !== challenge)
         return {errorMessage: "Invalid challenge: not the one provided"};
 
     // Parse registrationData.
@@ -255,8 +263,12 @@ function checkRegistration(request, registerData) {
 // signResult: {clientData, signatureData} - result of u2f.sign on client.
 // publicKey: string from user account.
 function checkSignature(request, signResult, publicKey) {
-    if (typeof signResult !== 'object')
+    if (typeof request !== 'object') {
+        return {errorMessage: "Invalid request object"};
+    }
+    if (typeof signResult !== 'object') {
         return {errorMessage: "Invalid response from U2F token."};
+    }
 
     // Check registration error
     if (signResult.errorCode)

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "homepage": "https://github.com/ashtuchkin/u2f",
   "devDependencies": {
     "mocha": "2"
+  },
+  "scripts": {
+    "test": "mocha"
   }
 }

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -36,13 +36,25 @@ describe("FIDO Specification v1.0-rd-20141008", function () {
             var keyHandle = new Buffer("2a552dfdb7477ed65fd84133f86196010b2215b57da75d315b7b9e8fe2e3925a6019551bab61d16591659cbaf00b4950f7abfe6660e2e006f76868b772d70c25", "hex");
             var registrationData = new Buffer("0504b174bc49c7ca254b70d2e5c207cee9cf174820ebd77ea3c65508c26da51b657c1cc6b952f8621697936482da0a6d3d3826a59095daf6cd7c03e2e60385d2f6d9402a552dfdb7477ed65fd84133f86196010b2215b57da75d315b7b9e8fe2e3925a6019551bab61d16591659cbaf00b4950f7abfe6660e2e006f76868b772d70c253082013c3081e4a003020102020a47901280001155957352300a06082a8648ce3d0403023017311530130603550403130c476e756262792050696c6f74301e170d3132303831343138323933325a170d3133303831343138323933325a3031312f302d0603550403132650696c6f74476e756262792d302e342e312d34373930313238303030313135353935373335323059301306072a8648ce3d020106082a8648ce3d030107034200048d617e65c9508e64bcc5673ac82a6799da3c1446682c258c463fffdf58dfd2fa3e6c378b53d795c4a4dffb4199edd7862f23abaf0203b4b8911ba0569994e101300a06082a8648ce3d0403020347003044022060cdb6061e9c22262d1aac1d96d8c70829b2366531dda268832cb836bcd30dfa0220631b1459f09e6330055722c8d89b7f48883b9089b88d60d1d9795902b30410df304502201471899bcc3987e62e8202c9b39c33c19033f7340352dba80fcab017db9230e402210082677d673d891933ade6f617e5dbde2e247e70423fd5ad7804a6d3d3961ef871", "hex");
             
+            var options = {timeoutSeconds: 100, requestId: 2, keyHandle: 'testHandle'};
+
             assert.equal(u2flib._hash(clientData).toString('hex'), "4142d21c00d94ffb9d504ada8f99b721f4b191ae4e37ca0140f696b6983cfacb");
             assert.equal(u2flib._hash(appId).toString('hex'), "f0e6a6a97042a4f1f1c87f5f7d44315b2d852c2df5c7991cc66241bf7072d1c4");
 
-            var request = u2flib.requestRegistration(appId);
-            // Convert multiple key request to single response
-            for(var key in request.RegisterRequest[0]) {
-                request[key] = request.RegisterRequest[0][key];
+            var request = u2flib.requestRegistration(appId, options);
+
+            // Check registration fields
+            assert.equal(request.appId, appId);
+            assert.equal(request.type, 'u2f_register_request');
+            assert.equal(request.registerRequests[0].appId, appId);
+            assert.equal(request.registerRequests[0].version, 'U2F_V2');
+            assert.equal(request.timeoutSeconds, options.timeoutSeconds);
+            assert.equal(request.requestId, options.requestId);
+            assert.equal(request.registeredKeys[0].keyHandle, options.keyHandle);
+
+            // Convert multiple key request to single response (client only returns one response)
+            for(var key in request.registerRequests[0]) {
+                request[key] = request.registerRequests[0][key];
             }
 
             request.challenge = "vqrS6WXDe1JUs5_c3i4-LkKIHRr-3XVb3azuA5TifHo"; // We have a fixed challenge.
@@ -68,10 +80,23 @@ describe("FIDO Specification v1.0-rd-20141008", function () {
             var clientData = '{"typ":"navigator.id.getAssertion","challenge":"opsXqUifDriAAmWclinfbS0e-USY0CgyJHe_Otd7z8o","cid_pubkey":{"kty":"EC","crv":"P-256","x":"HzQwlfXX7Q4S5MtCCnZUNBw3RMzPO9tOyWjBqRl4tJ8","y":"XVguGFLIZx1fXg3wNqfdbn75hi4-_7-BxhMljw42Ht4"},"origin":"http://example.com"}';
             var signatureData = new Buffer('0100000001304402204b5f0cd17534cedd8c34ee09570ef542a353df4436030ce43d406de870b847780220267bb998fac9b7266eb60e7cb0b5eabdfd5ba9614f53c7b22272ec10047a923f', 'hex');
 
+            var options = {timeoutSeconds: 100, requestId: 2};
+
             assert.equal(u2flib._hash(clientData).toString('hex'), "ccd6ee2e47baef244d49a222db496bad0ef5b6f93aa7cc4d30c4821b3b9dbc57");
             assert.equal(u2flib._hash(appId).toString('hex'), "4b0be934baebb5d12d26011b69227fa5e86df94e7d94aa2949a89f2d493992ca");
 
-            var request = u2flib.requestSignature(appId, '');
+            // Generate signature request
+            var request = u2flib.requestSignature(appId, '', options);
+            
+            // Check signature fields
+            assert.equal(request.appId, appId);
+            assert.equal(request.type, 'u2f_sign_request');
+            assert(typeof request.challenge !== 'undefined');
+            assert.equal(request.registeredKeys[0].keyHandle, '');
+            assert.equal(request.registeredKeys[0].version, 'U2F_V2');
+            assert.equal(request.timeoutSeconds, options.timeoutSeconds);
+            assert.equal(request.requestId, options.requestId);
+
             request.challenge = "opsXqUifDriAAmWclinfbS0e-USY0CgyJHe_Otd7z8o"; // We have a fixed challenge.
 
             var signResult = {

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -51,12 +51,8 @@ describe("FIDO Specification v1.0-rd-20141008", function () {
             assert.equal(request.requestId, options.requestId);
             assert.equal(request.registeredKeys[0].keyHandle, options.keyHandle);
 
-            // Convert multiple key request to single response (client only returns one response)
-            for(var key in request.registerRequests[0]) {
-                request[key] = request.registerRequests[0][key];
-            }
-
-            request.challenge = "vqrS6WXDe1JUs5_c3i4-LkKIHRr-3XVb3azuA5TifHo"; // We have a fixed challenge.
+            // Static registration key
+            request.registerRequests[0].challenge = "vqrS6WXDe1JUs5_c3i4-LkKIHRr-3XVb3azuA5TifHo"; // We have a fixed challenge.
 
             var result = {
                 clientData: u2flib._toWebsafeBase64(new Buffer(clientData)),

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -46,7 +46,6 @@ describe("FIDO Specification v1.0-rd-20141008", function () {
             // Check registration fields
             assert.equal(request.appId, appId);
             assert.equal(request.type, 'u2f_register_request');
-            assert.equal(request.registerRequests[0].appId, appId);
             assert.equal(request.registerRequests[0].version, 'U2F_V2');
             assert.equal(request.timeoutSeconds, options.timeoutSeconds);
             assert.equal(request.requestId, options.requestId);

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -39,7 +39,12 @@ describe("FIDO Specification v1.0-rd-20141008", function () {
             assert.equal(u2flib._hash(clientData).toString('hex'), "4142d21c00d94ffb9d504ada8f99b721f4b191ae4e37ca0140f696b6983cfacb");
             assert.equal(u2flib._hash(appId).toString('hex'), "f0e6a6a97042a4f1f1c87f5f7d44315b2d852c2df5c7991cc66241bf7072d1c4");
 
-            var request = u2flib.request(appId);
+            var request = u2flib.requestRegistration(appId);
+            // Convert multiple key request to single response
+            for(var key in request.RegisterRequest[0]) {
+                request[key] = request.RegisterRequest[0][key];
+            }
+
             request.challenge = "vqrS6WXDe1JUs5_c3i4-LkKIHRr-3XVb3azuA5TifHo"; // We have a fixed challenge.
 
             var result = {
@@ -66,7 +71,7 @@ describe("FIDO Specification v1.0-rd-20141008", function () {
             assert.equal(u2flib._hash(clientData).toString('hex'), "ccd6ee2e47baef244d49a222db496bad0ef5b6f93aa7cc4d30c4821b3b9dbc57");
             assert.equal(u2flib._hash(appId).toString('hex'), "4b0be934baebb5d12d26011b69227fa5e86df94e7d94aa2949a89f2d493992ca");
 
-            var request = u2flib.request(appId, '');
+            var request = u2flib.requestSignature(appId, '');
             request.challenge = "opsXqUifDriAAmWclinfbS0e-USY0CgyJHe_Otd7z8o"; // We have a fixed challenge.
 
             var signResult = {


### PR DESCRIPTION
Altered structures to support signing requests with multiple keyHandlers as required for use with multiple keys.

New messages based on spec [here](https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-javascript-api.html#dictionary-u2frequest-members).

Split API into requestRegistration(appid, options) and requestSignature(appId, keyHandle[s], options) where options are requestId and timeoutSeconds for both, and keyHandle[s] for requestRegistration.

This does break frontend compatibility as the base structures have changed slightly. Thoughts?
