### PR TITLE
Clarify registration/authentication instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,13 @@ function authenticationChallengeHandler(req, res) {
 }
 
 function authenticationVerificationHandler(req, res) {
-  // 4. Verify the authentication response from the client against the authentication request saved
+  // 5. Fetch the user's public key from the server-side datastore. This field should have been
+  // saved after the registration procedure.
+  const publicKey = ...
+
+  // 6. Verify the authentication response from the client against the authentication request saved
   // in the server-side session.
-  const result = u2f.checkSignature(req.session.authRequest, req.body.authResponse);
+  const result = u2f.checkSignature(req.session.authRequest, req.body.authResponse, publicKey);
 
   if (result.successful) {
     // Success!

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # U2F authentication library
 
-This is a simple library to register and check signatures provided by U2F clients/devices. 
+This is a simple library to register and check signatures provided by U2F clients/devices.
 It's intended to be used in Relying Parties - websites that want to add U2F 2-factor authentication
 for their users.
 
-To use U2F, it is recommended to familiarize yourself with [FIDO Alliance Specifications](https://fidoalliance.org/specifications/download/), 
+To use U2F, it is recommended to familiarize yourself with [FIDO Alliance Specifications](https://fidoalliance.org/specifications/download/),
 although basic usage is shown below.
 
 ## U2F Overview/properties
@@ -22,48 +22,116 @@ although basic usage is shown below.
 
 ### User Registration Flow
 
+##### Server endpoint (registration challenge):
+
 ```javascript
-// 1. Check that the user is logged in.
+const u2f = require('u2f');
 
-// 2. (On server) generate user registration request and save it in session:
-var u2f = require('u2f');
+function handler(req, res) {
+  // 1. Check that the user is logged in.
 
-var req = u2f.request("<appId>");
-session.authRequest = req;
+  // 2. Generate a registration request and save it in the session.
+  // The app ID is usually the fully qualified URL of your website. The website MUST be HTTPS, or
+  // else the registration will fail client-side.
+  const registrationReq = u2f.request('<appId>');
+  req.session.registrationReq = registrationReq;
 
-// 3. Send req to the client and use U2F API to request registration, then send result back.
-// (On client)  u2f.register([req], [], function(res) { /* send res back to server */ })
-
-// 4. (Server) Check registration result.
-var checkres = u2f.checkRegistration(session.authRequest, res);
-
-if (checkres.successful) {
-    // Registration successful, save 
-    // checkres.keyHandle and checkres.publicKey to user's account in your db.
-} else {
-    // checkres.errorMessage will contain error text.
+  // 3. Send the registration request to the client, who will use the Javascript U2F API to sign
+  // the registration request, and send it back to the server for verification.
+  return res.send(registrationReq);
 }
 ```
 
-### User Authentication Flow
+##### Server endpoint (registration verification):
+
 ```javascript
-// 1. Check that the user is logged in using password authentication (or some other way).
+const u2f = require('u2f');
 
-// 2. (On server) generate user sign request using keyHandle from user account.
-var req = u2f.request("<appId>", user.keyHandle);
-session.authRequest = req;
+function handler(req, res) {
+  // 4. Verify the registration response from the client against the registration request saved
+  // in the server-side session.
+  const result = u2f.checkRegistration(req.session.registrationReq, req.body.registrationRes);
 
-// 3. (On client) use U2F API to request signature.
-// u2f.sign([req], function(res) { /* send res back to server */ });
+  if (result.successful) {
+    // Success!
+    // Save result.publicKey and result.keyHandle to the server-side datastore, associated with
+    // this user.
+    return res.sendStatus(200);
+  }
 
-// 4. (On server) check signature using publicKey from user account.
-var checkres = u2f.checkSignature(session.authRequest, res, user.publicKey);
-
-if (checkres.successful) {
-    // User is authenticated.
-} else {
-    // checkres.errorMessage will contain error text.
+  // result.errorMessage is defined with an English-language description of the error.
+  return res.send({result});
 }
+```
+
+##### Client logic:
+
+Note that the `window.u2f` object is defined in the official [Javascript U2F API](https://github.com/google/u2f-ref-code), for which a polyfill is [available as an npm module](https://www.npmjs.com/package/u2f-api-polyfill).
+
+```javascript
+const registrationReq = ...  // Retrieve this from hitting the registration challenge endpoint
+const {appId, version, challenge} = registrationReq;
+
+window.u2f.register(appId, [{version, challenge}], [], (registrationRes) => {
+  // Send this registration response to the registration verification server endpoint
+});
+```
+
+### User Authentication Flow
+
+##### Server endpoint (authentication challenge):
+
+```javascript
+const u2f = require('u2f');
+
+function handler(req, res) {
+  // 1. Check that the user is logged in.
+
+  // 2. Fetch the user's key handle from the server-side datastore. This field should have been
+  // saved after the registration procedure.
+  const keyHandle = ...
+
+  // 3. Generate an authentication request and save it in the session. Use the same app ID that
+  // was used in registration!
+  const authReq = u2f.request('<appId>', keyHandle);
+  req.session.authReq = authReq;
+
+  // 4. Send the authentication request to the client, who will use the Javascript U2F API to sign
+  // the authentication request, and send it back to the server for verification.
+  return res.send(authReq);
+}
+```
+
+##### Server endpoint (authentication verification):
+
+```javascript
+const u2f = require('u2f');
+
+function handler(req, res) {
+  // 4. Verify the authentication response from the client against the authentication request saved
+  // in the server-side session.
+  const result = u2f.checkSignature(req.session.authReq, req.body.authRes);
+
+  if (result.successful) {
+    // Success!
+    // User is authenticated.
+    return res.sendStatus(200);
+  }
+
+  // result.errorMessage is defined with an English-language description of the error.
+  return res.send({result});
+}
+```
+
+##### Client logic:
+
+```javascript
+const authReq = ...;  // Retrieve this from hitting the authentication challenge endpoint
+const {appId, challenge, version, keyHandle} = authReq;
+
+window.u2f.sign(appId, challenge, [{version, keyHandle}], (authRes) => {
+  // Send this authentication response to the authentication verification server endpoint
+});
 ```
 
 ## Useful links
@@ -83,4 +151,3 @@ https://github.com/Yubico/python-u2flib-server
 # License
 
 MIT
-


### PR DESCRIPTION
Hi, thanks for creating this module! I've used it to implement U2F authentication in one of my [personal projects](https://github.com/LINKIWI/apache-auth) but had some trouble understanding the code examples in the README instructions to get everything working on both the server and client.

This PR clarifies the U2F registration/authentication instructions in the README, especially clarifying points of confusion I encountered as someone who is not familiar with the official U2F API spec.

I have also fixed an error on the client-side documentation. Namely, the existing `u2f` client calls are inconsistent with what the [official FIDO client-side API spec](https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-javascript-api.html) specifies as input to `window.u2f.register` and `window.u2f.sign`.