### PR TITLE
Don't error out on errorCode = 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function checkRegistration(request, registerData) {
         return {errorMessage: "Invalid response from U2F token."};
 
     // Check registration error
-    if (registerData.errorCode && registerData.errorCode !== 0)
+    if (registerData.errorCode && registerData.errorCode != 0)
         return {
             errorMessage: registerData.errorMessage || "Error registering U2F token.",
             errorCode: registerData.errorCode,
@@ -165,7 +165,7 @@ function checkSignature(request, signResult, publicKey) {
         return {errorMessage: "Invalid response from U2F token."};
 
     // Check registration error
-    if (signResult.errorCode && signResult.errorCode !== 0)
+    if (signResult.errorCode && signResult.errorCode != 0)
         return {
             errorMessage: signResult.errorMessage || "Error getting signature from U2F token.",
             errorCode: signResult.errorCode,

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function checkRegistration(request, registerData) {
         return {errorMessage: "Invalid response from U2F token."};
 
     // Check registration error
-    if (registerData.errorCode)
+    if (registerData.errorCode && registerData.errorCode !== 0)
         return {
             errorMessage: registerData.errorMessage || "Error registering U2F token.",
             errorCode: registerData.errorCode,
@@ -165,7 +165,7 @@ function checkSignature(request, signResult, publicKey) {
         return {errorMessage: "Invalid response from U2F token."};
 
     // Check registration error
-    if (signResult.errorCode)
+    if (signResult.errorCode && signResult.errorCode !== 0)
         return {
             errorMessage: signResult.errorMessage || "Error getting signature from U2F token.",
             errorCode: signResult.errorCode,


### PR DESCRIPTION
According to U2F spec error code `0` means `OK`. With Firefox adding U2F support to Firefox 57 we have found that it's registration response and sign response include `errorCode: '0'` which is causing this library to error out.

Error codes in spec: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-javascript-api-v1.2-ps-20170411.html#error-codes

Here is an example response to `u2f.register()` from Firefox 57:

```json
{
  "clientData": "eyJjaGFsbGVuZ2UiOiJiWU5hVWtOcTYwQzdBOVpRV1E0ekltNVBDc1VUVHhmUE1qNzRZWnY0ZDhrIiwib3JpZ2luIjoiaHR0cHM6Ly8zMDNhOGFhYi5uZ3Jvay5pbyIsInR5cCI6Im5hdmlnYXRvci5pZC5maW5pc2hFbnJvbGxtZW50In0",
  "errorCode": "0",
  "registrationData": "BQQ9iFbVRkx8rGl6J8e9R4RE4_6xrZXEHOe5N_3nENEYG6lGxPGiD3sxNEkgS5sAaVqK8gTJjy1q4Oa4xQ00p4teQDuytHdjp7jHgt2OFIniblXjsjytXQsFQi5t3oj5yuRflblpVMMT9FwNu2LMJxFUY734AlxImgJIiIdWlJG14qMwggJKMIIBMqADAgECAgQSSnL-MA0GCSqGSIb3DQEBCwUAMC4xLDAqBgNVBAMTI1l1YmljbyBVMkYgUm9vdCBDQSBTZXJpYWwgNDU3MjAwNjMxMCAXDTE0MDgwMTAwMDAwMFoYDzIwNTAwOTA0MDAwMDAwWjAsMSowKAYDVQQDDCFZdWJpY28gVTJGIEVFIFNlcmlhbCAyNDk0MTQ5NzIxNTgwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQ9ixu9L8v2CG4QdHFgFGhIQVPBxtO0topehV5uQHV-4ivNiYi_O-_XzfIcsL9dehUNhEr-mBA8bGYH2fquKHwCozswOTAiBgkrBgEEAYLECgIEFTEuMy42LjEuNC4xLjQxNDgyLjEuMTATBgsrBgEEAYLlHAIBAQQEAwIFIDANBgkqhkiG9w0BAQsFAAOCAQEAoU8e6gB29rhHahCivnLmDQJxu0ZbLfv8fBvRLTUZiZFwMmMdeV0Jf6MKJqMlY06FchvC0BqGMD9rwHXlmXMZ4SIUiwSW7sjR9PlM9BEN5ibCiUQ9Hw9buyOcoT6B0dWqnfWvjjYSZHW_wjrwYoMVclJ2L_aIebzw71eNVdZ_lRtPMrY8iupbD5nGfX2BSn_1pvUt-D6JSjpdnIuC5_i8ja9MgBdf-Jcv2nkzPsRl2AbqzJSPG6siBFqVVYpIwgIm2sAD1B-8ngXqKKa7XhCkneBgoKT2omdqNNaMSr6MYYdDVbkCfoKMqeBksALWLo2M8HRJIXU9NePIfF1XeUU-dzBFAiEA6DmAzflSQbplzQexoCFUq9dFlPi8rRNyrVgxSE4UHGECIFnADOJG-f2FJ1b_pJiUu5ZWFEhhDnA4P-aJahl9XDNK",
  "version": "U2F_V2"
}
```